### PR TITLE
Different behavior with Empty/NULL fields

### DIFF
--- a/.github/workflows/kafka_api_ci_tests.yml
+++ b/.github/workflows/kafka_api_ci_tests.yml
@@ -77,6 +77,11 @@ jobs:
             export PATH=/snap/bin:$PATH
           fi
 
+          # 2. Install clang-tidy
+          if [[ ${CHECK_OPTION} == *"clang-tidy"* ]]; then
+            sudo apt install -y clang-tidy
+          fi
+
           # 2. Install googletest (v1.10.0)
           wget -nv https://github.com/google/googletest/archive/release-1.10.0.tar.gz
           tar -xzf release-1.10.0.tar.gz
@@ -120,7 +125,7 @@ jobs:
           fi
 
           if [[ ${CHECK_OPTION} == *"clang-tidy"* ]]; then
-            export BUILD_OPTION='-DBUILD_OPTION_CLANG_TIEY=ON'
+            export BUILD_OPTION='-DBUILD_OPTION_CLANG_TIDY=ON'
           fi
 
           if [[ ${CHECK_OPTION} == *"asan"* ]]; then

--- a/include/kafka/BrokerMetadata.h
+++ b/include/kafka/BrokerMetadata.h
@@ -55,7 +55,8 @@ struct BrokerMetadata {
      */
     struct PartitionInfo
     {
-        void setLeader(Node::Id id)        { leader = id; }
+        explicit PartitionInfo(Node::Id leaderId): leader(leaderId) {}
+
         void addReplica(Node::Id id)       { replicas.emplace_back(id); }
         void addInSyncReplica(Node::Id id) { inSyncReplicas.emplace_back(id); }
 
@@ -148,7 +149,7 @@ BrokerMetadata::toString(const PartitionInfo& partitionInfo) const
 {
     std::ostringstream oss;
 
-    auto streamNodes = [this](std::ostringstream& ss, const std::vector<Node::Id> nodeIds) -> std::ostringstream& {
+    auto streamNodes = [this](std::ostringstream& ss, const std::vector<Node::Id>& nodeIds) -> std::ostringstream& {
         bool isTheFirst = true;
         for (const auto id: nodeIds)
         {

--- a/include/kafka/KafkaClient.h
+++ b/include/kafka/KafkaClient.h
@@ -514,8 +514,6 @@ KafkaClient::fetchBrokerMetadata(const std::string& topic, std::chrono::millisec
 
         Partition partition = metadata_partition.id;
 
-        BrokerMetadata::PartitionInfo partitionInfo;
-
         if (metadata_partition.err != 0)
         {
             if (!disableErrorLogging)
@@ -526,7 +524,7 @@ KafkaClient::fetchBrokerMetadata(const std::string& topic, std::chrono::millisec
             continue;
         }
 
-        partitionInfo.setLeader(metadata_partition.leader);
+        BrokerMetadata::PartitionInfo partitionInfo(metadata_partition.leader);
 
         for (int j = 0; j < metadata_partition.replica_cnt; ++j)
         {

--- a/include/kafka/Types.h
+++ b/include/kafka/Types.h
@@ -90,6 +90,8 @@ public:
     std::size_t size()     const { return _size; }
     std::string toString() const
     {
+        if (_size == 0) return _data ? "[empty]" : "[NULL]";
+
         std::ostringstream oss;
 
         auto printChar = [&oss](const unsigned char c) {

--- a/tests/integration/TestKafkaConsumer.cc
+++ b/tests/integration/TestKafkaConsumer.cc
@@ -174,6 +174,95 @@ TEST(KafkaAutoCommitConsumer, PollWithHeaders)
     consumer.close();
 }
 
+TEST(KafkaAutoCommitConsumer, RecordWithEmptyOrNullFields)
+{
+    auto sendMessages = [](const Kafka::ProducerRecord& record, std::size_t repeat, const std::string& partitioner) {
+        Kafka::KafkaSyncProducer producer(KafkaTestUtility::GetKafkaClientCommonConfig()
+                                          .put(ProducerConfig::PARTITIONER, partitioner));
+        producer.setLogLevel(LOG_CRIT);
+        for (std::size_t i = 0; i < repeat; ++i) {
+            producer.send(record);
+        }
+    };
+
+    std::cout << "[" << Utility::getCurrentTime() << "] Try with messages with empty fields" << std::endl;
+    {
+        const Topic topic = Utility::getRandomString();
+        KafkaTestUtility::CreateKafkaTopic(topic, 5, 3);
+
+        const std::string emptyStr{};
+        const auto emptyField = ConstBuffer(emptyStr.c_str(), emptyStr.size());
+
+        auto recordWithEmptyFields = Kafka::ProducerRecord(topic, emptyField, emptyField);
+
+        // murmur2_random, -- NULL (NOTE: not empty) keys are randomly partitioned.
+        // This is the default for `modern-cpp-kafka` API (also is the default partitioner in the Java Producer)
+        sendMessages(recordWithEmptyFields, 10, "murmur2_random");
+
+        // The auto-commit consumer
+        KafkaAutoCommitConsumer consumer(KafkaTestUtility::GetKafkaClientCommonConfig()
+                                         .put(ConsumerConfig::AUTO_OFFSET_RESET, "earliest"));
+        // Subscribe topics
+        consumer.subscribe({topic});
+
+        // Poll all messages
+        auto records = KafkaTestUtility::ConsumeMessagesUntilTimeout(consumer, std::chrono::seconds(1));
+
+        // Check the key/value (should be empty: 0 length, but not NULL)
+        std::map<int, int> counts;
+        for (const auto& record: records)
+        {
+            std::cout << record.toString() << std::endl;
+
+            EXPECT_TRUE(record.key().size()   == 0);
+            EXPECT_TRUE(record.value().size() == 0);
+            EXPECT_TRUE(record.key().data()   != nullptr);
+            EXPECT_TRUE(record.value().data() != nullptr);
+
+            counts[record.partition()] += 1;
+        }
+        // Should be hashed to the same partition (with empty key)
+        EXPECT_TRUE(counts.size() == 1);
+    }
+
+    std::cout << "[" << Utility::getCurrentTime() << "] Try with messages with NULL fields" << std::endl;
+    {
+        const Topic topic = Utility::getRandomString();
+        KafkaTestUtility::CreateKafkaTopic(topic, 5, 3);
+
+        auto recordWithNullFields = Kafka::ProducerRecord(topic, Kafka::NullKey, Kafka::NullValue);
+
+        // murmur2_random, -- NULL (NOTE: not empty) keys are randomly partitioned.
+        // This is the default for `modern-cpp-kafka` API (also is the default partitioner in the Java Producer)
+        sendMessages(recordWithNullFields, 10, "murmur2_random");
+
+        // The auto-commit consumer
+        KafkaAutoCommitConsumer consumer(KafkaTestUtility::GetKafkaClientCommonConfig()
+                                         .put(ConsumerConfig::AUTO_OFFSET_RESET, "earliest"));
+        // Subscribe topics
+        consumer.subscribe({topic});
+
+        // Poll all messages
+        auto records = KafkaTestUtility::ConsumeMessagesUntilTimeout(consumer, std::chrono::seconds(1));
+
+        // Check the key/value (should be NULL)
+        std::map<int, int> counts;
+        for (const auto& record: records)
+        {
+            std::cout << record.toString() << std::endl;
+
+            EXPECT_TRUE(record.key().size()   == 0);
+            EXPECT_TRUE(record.value().size() == 0);
+            EXPECT_TRUE(record.key().data()   == nullptr);
+            EXPECT_TRUE(record.value().data() == nullptr);
+
+            counts[record.partition()] += 1;
+        }
+        // Should be hashed to random partitions (with NULL key)
+        EXPECT_TRUE(counts.size() > 1);
+    }
+}
+
 TEST(KafkaAutoCommitConsumer, SeekAndPoll)
 {
     const Topic     topic     = Utility::getRandomString();

--- a/tests/unit/TestBrokerMetadata.cc
+++ b/tests/unit/TestBrokerMetadata.cc
@@ -39,8 +39,7 @@ TEST(BrokerMetadata, Basic)
     // Add info for partitions
     for (Kafka::Partition partition = 0; partition < numPartition; ++partition)
     {
-        Kafka::BrokerMetadata::PartitionInfo partitionInfo;
-        partitionInfo.setLeader(nodes[partition].id);
+        Kafka::BrokerMetadata::PartitionInfo partitionInfo(nodes[partition].id);
         for (const auto& node: nodes)
         {
             partitionInfo.addReplica(node.id);
@@ -83,8 +82,7 @@ TEST(BrokerMetadata, IncompleteInfo)
     // Add info for partitions
     for (Kafka::Partition partition = 0; partition < numPartition; ++partition)
     {
-        Kafka::BrokerMetadata::PartitionInfo partitionInfo;
-        partitionInfo.setLeader(nodes[partition].id);
+        Kafka::BrokerMetadata::PartitionInfo partitionInfo(nodes[partition].id);
         for (const auto& node: nodes)
         {
             partitionInfo.addReplica(node.id);


### PR DESCRIPTION
1. Fix the typo in workflow which disabled the clany-tidy check accidentally.
2. Fix the clang-tidy warnings for `BrokerMetadata`.
3. New integration testcase to verify the behavior about empty/NULL fields for record key/value.