### PR TITLE
Add testcases for KafkaConsumer rebalance event callback

### DIFF
--- a/include/kafka/Header.h
+++ b/include/kafka/Header.h
@@ -40,6 +40,15 @@ struct Header
 using Headers = std::vector<Header>;
 
 /**
+ * Null Headers.
+ */
+#if __cplusplus >= 201703L
+const inline Headers NullHeaders = Headers{};
+#else
+const static Headers NullHeaders = Headers{};
+#endif
+
+/**
  * Obtains explanatory string for Headers.
  */
 inline std::string toString(const Headers& headers)


### PR DESCRIPTION
Add testcases for the previous commit `Avoid "generation id invalid" error when committing offset during rebalance`