### PR TITLE
Add SASL_LIBRARY link to all sub projects.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -197,6 +197,18 @@ if (BUILD_OPTION_GEN_COVERAGE)
     message(STATUS "Enable code coverage data generation")
 endif ()
 
+#---------------------------
+# Check sasl lib directory
+#---------------------------
+if(DEFINED ENV{SASL_LIBRARYDIR})
+    set(SASL_LIBRARYDIR $ENV{SASL_LIBRARYDIR})
+    link_directories(${SASL_LIBRARYDIR})
+    message(STATUS "sasl2 library directory: ${SASL_LIBRARYDIR}")
+endif()
+if(DEFINED ENV{SASL_LIBRARY})
+    set(SASL_LIBRARY $ENV{SASL_LIBRARY})
+    message(STATUS "sasl2 library: ${SASL_LIBRARY}")
+endif()
 
 #---------------------------
 # Build Sub-directories

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -2,23 +2,23 @@ project("kafka-examples")
 
 # Target: kafka_sync_producer
 add_executable("kafka_sync_producer" "kafka_sync_producer.cc")
-target_link_libraries("kafka_sync_producer" modern-cpp-kafka-api)
+target_link_libraries("kafka_sync_producer" modern-cpp-kafka-api ${SASL_LIBRARY})
 
 # Target: kafka_async_producer_copy_payload
 add_executable("kafka_async_producer_copy_payload" "kafka_async_producer_copy_payload.cc")
 target_link_libraries("kafka_async_producer_copy_payload" modern-cpp-kafka-api)
-target_link_libraries("kafka_async_producer_copy_payload" "pthread")
+target_link_libraries("kafka_async_producer_copy_payload" "pthread" ${SASL_LIBRARY})
 
 # Target: kafka_async_producer_not_copy_payload
 add_executable("kafka_async_producer_not_copy_payload" "kafka_async_producer_not_copy_payload.cc")
 target_link_libraries("kafka_async_producer_not_copy_payload" modern-cpp-kafka-api)
-target_link_libraries("kafka_async_producer_not_copy_payload" "pthread")
+target_link_libraries("kafka_async_producer_not_copy_payload" "pthread" ${SASL_LIBRARY})
 
 # Target: kafka_auto_commit_consumer
 add_executable("kafka_auto_commit_consumer" "kafka_auto_commit_consumer.cc")
-target_link_libraries("kafka_auto_commit_consumer" modern-cpp-kafka-api)
+target_link_libraries("kafka_auto_commit_consumer" modern-cpp-kafka-api ${SASL_LIBRARY})
 
 # Target: kafka_manual_commit_consumer
 add_executable("kafka_manual_commit_consumer" "kafka_manual_commit_consumer.cc")
 target_link_libraries("kafka_manual_commit_consumer" modern-cpp-kafka-api)
-target_link_libraries("kafka_manual_commit_consumer" "pthread")
+target_link_libraries("kafka_manual_commit_consumer" "pthread" ${SASL_LIBRARY})

--- a/tests/integration/CMakeLists.txt
+++ b/tests/integration/CMakeLists.txt
@@ -9,7 +9,7 @@ file(GLOB TEST_SRCS *.cc)
 
 add_executable("${PROJECT_NAME}" ${TEST_SRCS})
 
-target_link_libraries("${PROJECT_NAME}" modern-cpp-kafka-api gtest gtest_main pthread)
+target_link_libraries("${PROJECT_NAME}" modern-cpp-kafka-api gtest gtest_main pthread ${SASL_LIBRARY})
 
 add_test(NAME ${PROJECT_NAME} COMMAND ./${PROJECT_NAME})
 set_tests_properties(${PROJECT_NAME} PROPERTIES LABELS "IT")

--- a/tests/robustness/CMakeLists.txt
+++ b/tests/robustness/CMakeLists.txt
@@ -9,7 +9,7 @@ file(GLOB TEST_SRCS *.cc)
 
 add_executable("${PROJECT_NAME}" ${TEST_SRCS})
 
-target_link_libraries("${PROJECT_NAME}" modern-cpp-kafka-api gtest gmock gtest_main pthread)
+target_link_libraries("${PROJECT_NAME}" modern-cpp-kafka-api gtest gmock gtest_main pthread ${SASL_LIBRARY})
 
 add_test(NAME ${PROJECT_NAME} COMMAND ./${PROJECT_NAME})
 set_tests_properties(${PROJECT_NAME} PROPERTIES LABELS "RT")

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -5,7 +5,7 @@ file(GLOB TEST_SRCS *.cc)
 
 add_executable("${PROJECT_NAME}" ${TEST_SRCS})
 
-target_link_libraries("${PROJECT_NAME}" modern-cpp-kafka-api rdkafka gtest gtest_main pthread)
+target_link_libraries("${PROJECT_NAME}" modern-cpp-kafka-api rdkafka gtest gtest_main pthread ${SASL_LIBRARY})
 
 add_test(NAME ${PROJECT_NAME} COMMAND ./${PROJECT_NAME})
 set_tests_properties(${PROJECT_NAME} PROPERTIES LABELS "UT")

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -26,20 +26,6 @@ else()
     message(FATAL_ERROR "Could not find library: pthread!")
 endif()
 
-#---------------------------
-# Check sasl lib directory
-#---------------------------
-if(DEFINED ENV{SASL_LIBRARYDIR})
-    set(SASL_LIBRARYDIR $ENV{SASL_LIBRARYDIR})
-    link_directories(${SASL_LIBRARYDIR})
-    message(STATUS "sasl2 library directory: ${SASL_LIBRARYDIR}")
-endif()
-if(DEFINED ENV{SASL_LIBRARY})
-    set(SASL_LIBRARY $ENV{SASL_LIBRARY})
-    message(STATUS "sasl2 library: ${SASL_LIBRARY}")
-endif()
-
-
 # Directories
 include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
 link_directories(${Boost_LIBRARY_DIRS})


### PR DESCRIPTION
Currently, if SASL_LIBRARY is needed, several sub projects cannot be built because SASL_LIBRARY is not added to the these targets' linked libraries list, and linking will fail.