### PR TITLE
Unify KafkaProducers (i.e. KafkaAsyncProducer & KafkaSyncProducer)

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,12 @@ Eventually, we worked out the ***modern-cpp-kafka***, -- a header-only library t
 
             * KafkaConsumer
 
+                * Properties with random string as default
+
+                    * `client.id`
+
+                    * `group.id`
+
                 * More properties than ***librdkafka***
 
                     * `max.poll.records` (default: `500`): The maxmum number of records that a single call to `poll()` would return
@@ -178,19 +184,7 @@ Eventually, we worked out the ***modern-cpp-kafka***, -- a header-only library t
 
                     * `auto.commit.interval.ms`
 
-                * Properties with random string as default
-
-                    * `client.id`
-
-                    * `group.id`
-
             * KafkaProducer
-
-                * Different default value from ***librdkafka***
-
-                    * KafkaSyncProducer
-
-                        * `linger.ms` (default: `0`)
 
                 * Properties with random string as default
 

--- a/doc/HowToMakeKafkaProducerReliable.md
+++ b/doc/HowToMakeKafkaProducerReliable.md
@@ -64,7 +64,7 @@ Here we'd focus on `KafkaProducer`, together with the `idempotence` feature. Let
 
 ### How to guarantee `Exactly Once`
 
-* The `enable.idempotence` configuration would resolve such a problem. And this configuration is RECOMMENDED for both `KafkaSyncProducer` and `KafkaAsyncProducer`, as long as it's possible.
+* The `enable.idempotence` configuration is RECOMMENDED.
 
 
 ## About `Ordering`
@@ -150,48 +150,12 @@ The `msgid` is used, (along with a base `msgid` value stored at the time the `PI
 
 ## Some examples
 
-### `KafkaSyncProducer` demo
-
-```cpp
-    int ret = 0;
-    std::atomic<bool> running = true;
-
-    KafkaSyncProducer producer(
-        Properties({
-            { ProducerConfig::BOOTSTRAP_SERVERS,  "192.168.0.1:9092,192.168.0.2:9092,192.168.0.3:9092" },
-            { ProducerConfig::ENABLE_IDEMPOTENCE, "true" },
-            { ProducerConfig::MESSAGE_TIMEOUT_MS, "60000"}
-        })
-    );
-
-    while (running) {
-        const auto& msg = topMsgOfUpstream();
-        try {
-            auto record = ProducerRecord(topic, msg.key, msg.value);
-            producer.send(record);
-            popMsgFromUpstream();
-        } catch (const KafkaException& e) {
-            std::cerr << "Failed to send message! Reason: " << e.what() << std::endl;        
-            ret = e.error();
-            break;
-        }
-    }
-
-    producer.close();
-
-    return ret;
-```
-
-* It's easy to use `KafkaSyncProducer`, since it sends messages one by one. 
-
-* The throughput performance would not be that good, since there's only 1 message (embedded in 1 message batch) on the flight.
-
-### `KafkaAsyncProducer` demo
+### `KafkaProducer` demo
 
 ```cpp
     std::atomic<bool> running = true;
 
-    KafkaAsyncProducer producer(
+    KafkaProducer producer(
         Properties({
             { ProducerConfig::BOOTSTRAP_SERVERS,  "192.168.0.1:9092,192.168.0.2:9092,192.168.0.3:9092" },
             { ProducerConfig::ENABLE_IDEMPOTENCE, "true" },

--- a/examples/kafka_async_producer_copy_payload.cc
+++ b/examples/kafka_async_producer_copy_payload.cc
@@ -23,7 +23,7 @@ int main(int argc, char **argv)
         });
 
         // Create a producer instance.
-        kafka::KafkaAsyncProducer producer(props);
+        kafka::KafkaProducer producer(props);
 
         // Read messages from stdin and produce to the broker.
         std::cout << "% Type message value and hit enter to produce message. (empty line to quit)" << std::endl;

--- a/examples/kafka_async_producer_not_copy_payload.cc
+++ b/examples/kafka_async_producer_not_copy_payload.cc
@@ -23,7 +23,7 @@ int main(int argc, char **argv)
         });
 
         // Create a producer instance.
-        kafka::KafkaAsyncProducer producer(props);
+        kafka::KafkaProducer producer(props);
 
         // Read messages from stdin and produce to the broker.
         std::cout << "% Type message value and hit enter to produce message. (empty line to quit)" << std::endl;

--- a/examples/kafka_sync_producer.cc
+++ b/examples/kafka_sync_producer.cc
@@ -22,7 +22,7 @@ int main(int argc, char **argv)
         });
 
         // Create a producer instance.
-        kafka::KafkaSyncProducer producer(props);
+        kafka::KafkaProducer producer(props);
 
         // Read messages from stdin and produce to the broker.
         std::cout << "% Type message value and hit enter to produce message. (empty line to quit)" << std::endl;
@@ -35,7 +35,7 @@ int main(int argc, char **argv)
 
             // Send the message.
             try {
-                kafka::Producer::RecordMetadata metadata = producer.send(record);
+                kafka::Producer::RecordMetadata metadata = producer.syncSend(record);
                 std::cout << "% Message delivered: " << metadata.toString() << std::endl;
             } catch (const kafka::KafkaException& e) {
                 std::cerr << "% Message delivery failed: " << e.error().message() << std::endl;

--- a/include/kafka/ProducerRecord.h
+++ b/include/kafka/ProducerRecord.h
@@ -20,10 +20,17 @@ public:
     using Id  = std::uint64_t;
 
     // Note: ProducerRecord would not take the ownership from these parameters,
-    ProducerRecord(Topic topic, Partition partition, const Key& key, const Value& value, Id id = 0)
-       : _topic(std::move(topic)), _partition(partition), _key(key), _value(value), _id(id) {}
-    ProducerRecord(const Topic& topic, const Key& key, const Value& value, Id id = 0)
-        : ProducerRecord(topic, RD_KAFKA_PARTITION_UA, key, value, id) {}
+    ProducerRecord(Topic topic, Partition partition, const Key& key, const Value& value)
+       : _topic(std::move(topic)), _partition(partition), _key(key), _value(value) {}
+
+    ProducerRecord(const Topic& topic, Partition partition, const Key& key, const Value& value, Id id)
+        : ProducerRecord(topic, partition, key, value) { _id = id; }
+
+    ProducerRecord(const Topic& topic, const Key& key, const Value& value)
+        : ProducerRecord(topic, RD_KAFKA_PARTITION_UA, key, value) {}
+
+    ProducerRecord(const Topic& topic, const Key& key, const Value& value, Id id)
+        : ProducerRecord(topic, key, value) { _id = id; }
 
     /**
      * The topic this record is being sent to.
@@ -48,7 +55,7 @@ public:
     /**
      * The id to identify the message (consistent with `Producer::Metadata::recordId()`).
      */
-    Id        id()        const { return _id; }
+    Optional<Id>   id()      const { return _id; }
 
     /**
      * The headers.
@@ -83,18 +90,19 @@ public:
 
     std::string toString() const
     {
-        return _topic + "-" + (_partition == RD_KAFKA_PARTITION_UA ? "NA" : std::to_string(_partition)) + std::string(":") + std::to_string(_id)
-            + std::string(", ") + (_headers.empty() ? "" : ("headers[" + KAFKA_API::toString(_headers) + "], "))
+        return _topic + "-" + (_partition == RD_KAFKA_PARTITION_UA ? "NA" : std::to_string(_partition)) + std::string(":")
+            + (_id ? (std::to_string(*_id) + std::string(", ")) : " ")
+            + (_headers.empty() ? "" : ("headers[" + KAFKA_API::toString(_headers) + "], "))
             + _key.toString() + std::string("/") + _value.toString();
     }
 
 private:
-    Topic     _topic;
-    Partition _partition;
-    Key       _key;
-    Value     _value;
-    Id        _id;
-    Headers   _headers;
+    Topic        _topic;
+    Partition    _partition;
+    Key          _key;
+    Value        _value;
+    Headers      _headers;
+    Optional<Id> _id;
 };
 
 }

--- a/tests/integration/TestKafkaConsumer.cc
+++ b/tests/integration/TestKafkaConsumer.cc
@@ -1559,21 +1559,21 @@ TEST(KafkaManualCommitConsumer, OffsetsForTime)
 
     std::cout << "Produce messages:" << std::endl;
     {
-        Kafka::KafkaSyncProducer producer(KafkaTestUtility::GetKafkaClientCommonConfig());
+        Kafka::KafkaProducer producer(KafkaTestUtility::GetKafkaClientCommonConfig());
         for (int i = 0; i < MESSAGES_NUM; ++i)
         {
             checkPoints.emplace_back(system_clock::now());
 
             TopicPartitionOffsets expected;
 
-            auto metadata1 = producer.send(Kafka::ProducerRecord(topic1, partition1, Kafka::NullKey, Kafka::NullValue));
+            auto metadata1 = producer.syncSend(Kafka::ProducerRecord(topic1, partition1, Kafka::NullKey, Kafka::NullValue));
             std::cout << "[" << Utility::getCurrentTime() << "] Just send a message, metadata: " << metadata1.toString() << std::endl;
             if (auto offset = metadata1.offset())
             {
                 expected[{topic1, partition1}] = *offset;
             }
 
-            auto metadata2 = producer.send(Kafka::ProducerRecord(topic2, partition2, Kafka::NullKey, Kafka::NullValue));
+            auto metadata2 = producer.syncSend(Kafka::ProducerRecord(topic2, partition2, Kafka::NullKey, Kafka::NullValue));
             std::cout << "[" << Utility::getCurrentTime() << "] Just send a message, metadata: " << metadata2.toString() << std::endl;
             if (auto offset = metadata2.offset())
             {
@@ -1673,14 +1673,14 @@ TEST(KafkaManualCommitConsumer, RecoverByTime)
 
     // Send the messages
     {
-        Kafka::KafkaSyncProducer producer(KafkaTestUtility::GetKafkaClientCommonConfig());
+        Kafka::KafkaProducer producer(KafkaTestUtility::GetKafkaClientCommonConfig());
         for (const auto& msg: messages)
         {
             auto record = Kafka::ProducerRecord(topic,
                                                 partition,
                                                 Kafka::Key(msg.first.c_str(), msg.first.size()),
                                                 Kafka::Value(msg.second.c_str(), msg.second.size()));
-            auto metadata = producer.send(record);
+            auto metadata = producer.syncSend(record);
 
             std::cout << "[" << Utility::getCurrentTime() << "] Just sent a message: " << record.toString() << ", metadata: " << metadata.toString() << std::endl;
             std::this_thread::sleep_for(std::chrono::milliseconds(1));

--- a/tests/integration/TestKafkaProducer.cc
+++ b/tests/integration/TestKafkaProducer.cc
@@ -11,7 +11,7 @@
 using namespace KAFKA_API;
 
 
-TEST(KafkaSyncProducer, SendMessagesWithAcks1)
+TEST(KafkaProducer, SendMessagesWithAcks1)
 {
     // Prepare messages to test
     const std::vector<std::pair<std::string, std::string>> messages = {
@@ -29,14 +29,14 @@ TEST(KafkaSyncProducer, SendMessagesWithAcks1)
     const auto props = KafkaTestUtility::GetKafkaClientCommonConfig().put(ProducerConfig::ACKS, "1");
 
     // Sync-send producer
-    KafkaSyncProducer producer(props);
+    KafkaProducer producer(props);
 
     // Send messages
     for (const auto& msg: messages)
     {
         auto record = ProducerRecord(topic, partition, Key(msg.first.c_str(), msg.first.size()), Value(msg.second.c_str(), msg.second.size()));
         std::cout << "[" << Utility::getCurrentTime() << "] ProducerRecord: " << record.toString() << std::endl;
-        auto metadata = producer.send(record);
+        auto metadata = producer.syncSend(record);
         std::cout << "[" << Utility::getCurrentTime() << "] Producer::Metadata: " << metadata.toString() << std::endl;
     }
 
@@ -57,7 +57,7 @@ TEST(KafkaSyncProducer, SendMessagesWithAcks1)
     }
 }
 
-TEST(KafkaSyncProducer, SendMessagesWithAcksAll)
+TEST(KafkaProducer, SendMessagesWithAcksAll)
 {
     // Prepare messages to test
     const std::vector<std::pair<std::string, std::string>> messages = {
@@ -75,14 +75,14 @@ TEST(KafkaSyncProducer, SendMessagesWithAcksAll)
     const auto props = KafkaTestUtility::GetKafkaClientCommonConfig().put(ProducerConfig::ACKS, "all");
 
     // Async-send producer
-    KafkaSyncProducer producer(props);
+    KafkaProducer producer(props);
 
     // Send messages
     for (const auto& msg: messages)
     {
         auto record = ProducerRecord(topic, partition, Key(msg.first.c_str(), msg.first.size()), Value(msg.second.c_str(), msg.second.size()));
         std::cout << "[" << Utility::getCurrentTime() << "] ProducerRecord: " << record.toString() << std::endl;
-        auto metadata = producer.send(record);
+        auto metadata = producer.syncSend(record);
         std::cout << "[" << Utility::getCurrentTime() << "] Producer::Metadata: " << metadata.toString() << std::endl;
     }
 
@@ -104,7 +104,7 @@ TEST(KafkaSyncProducer, SendMessagesWithAcksAll)
     }
 }
 
-TEST(KafkaSyncProducer, FailToSendMessagesWithAcksAll)
+TEST(KafkaProducer, FailToSendMessagesWithAcksAll)
 {
     // Prepare messages to test
     const std::vector<std::pair<std::string, std::string>> messages = {
@@ -125,7 +125,7 @@ TEST(KafkaSyncProducer, FailToSendMessagesWithAcksAll)
                         .put(ProducerConfig::MESSAGE_TIMEOUT_MS, "5000"); // To shorten the test
 
     // Async-send producer
-    KafkaSyncProducer producer(props);
+    KafkaProducer producer(props);
 
     if (auto brokerMetadata = producer.fetchBrokerMetadata(topic))
     {
@@ -138,11 +138,11 @@ TEST(KafkaSyncProducer, FailToSendMessagesWithAcksAll)
         auto record = ProducerRecord(topic, Key(msg.first.c_str(), msg.first.size()), Value(msg.second.c_str(), msg.second.size()));
         std::cout << "[" << Utility::getCurrentTime() << "] ProducerRecord: " << record.toString() << std::endl;
         // Since "no in-sync replica" for the topic, it would keep trying
-        EXPECT_KAFKA_THROW(producer.send(record), RD_KAFKA_RESP_ERR__MSG_TIMED_OUT);
+        EXPECT_KAFKA_THROW(producer.syncSend(record), RD_KAFKA_RESP_ERR__MSG_TIMED_OUT);
     }
 }
 
-TEST(KafkaSyncProducer, InSyncBrokersAckTimeout)
+TEST(KafkaProducer, InSyncBrokersAckTimeout)
 {
     const Topic     topic     = Utility::getRandomString();
     const Partition partition = 0;
@@ -159,14 +159,14 @@ TEST(KafkaSyncProducer, InSyncBrokersAckTimeout)
                            .put(ProducerConfig::MESSAGE_TIMEOUT_MS, "1000")
                            .put(ProducerConfig::REQUEST_TIMEOUT_MS, "1"); // Here it's a short value, more likely to trigger the timeout
 
-        KafkaSyncProducer producer(props);
+        KafkaProducer producer(props);
 
         constexpr int MAX_RETRIES = 100;
         for (int i = 0; i < MAX_RETRIES; ++i)
         {
             try
             {
-                auto metadata = producer.send(record);
+                auto metadata = producer.syncSend(record);
                 // will retry, to see if timeout could occure next time
             }
             catch (const KafkaException& e)
@@ -179,9 +179,9 @@ TEST(KafkaSyncProducer, InSyncBrokersAckTimeout)
     }
 }
 
-TEST(KafkaSyncProducer, DefaultPartitioner)
+TEST(KafkaProducer, DefaultPartitioner)
 {
-    KafkaSyncProducer producer(KafkaTestUtility::GetKafkaClientCommonConfig());
+    KafkaProducer producer(KafkaTestUtility::GetKafkaClientCommonConfig());
 
     const Topic topic = Utility::getRandomString();
     KafkaTestUtility::CreateKafkaTopic(topic, 5, 3);
@@ -195,7 +195,7 @@ TEST(KafkaSyncProducer, DefaultPartitioner)
 
         auto record = ProducerRecord(topic, Key(key.c_str(), key.size()), Value(value.c_str(), value.size()));
 
-        auto metadata = producer.send(record);
+        auto metadata = producer.syncSend(record);
 
         partitionCounts[metadata.partition()]++;
     }
@@ -204,7 +204,7 @@ TEST(KafkaSyncProducer, DefaultPartitioner)
     for (const auto& count: partitionCounts) EXPECT_NE(MSG_NUM, count.second);
 }
 
-TEST(KafkaSyncProducer, TryOtherPartitioners)
+TEST(KafkaProducer, TryOtherPartitioners)
 {
     const Topic topic = Utility::getRandomString();
     KafkaTestUtility::CreateKafkaTopic(topic, 5, 3);
@@ -215,7 +215,7 @@ TEST(KafkaSyncProducer, TryOtherPartitioners)
         // Partitioner "murmur2": if with no available key, all these records would be partitioned to the same partition
         props.put(ProducerConfig::PARTITIONER, "murmur2");
 
-        KafkaSyncProducer producer(props);
+        KafkaProducer producer(props);
 
         std::map<Partition, int> partitionCounts;
         static constexpr int MSG_NUM = 20;
@@ -226,7 +226,7 @@ TEST(KafkaSyncProducer, TryOtherPartitioners)
 
             auto record = ProducerRecord(topic, Key(key.c_str(), key.size()), Value(value.c_str(), value.size()));
 
-            auto metadata = producer.send(record);
+            auto metadata = producer.syncSend(record);
             std::cout << metadata.toString() << std::endl;
 
             partitionCounts[metadata.partition()]++;
@@ -243,18 +243,18 @@ TEST(KafkaSyncProducer, TryOtherPartitioners)
         props.put(ProducerConfig::PARTITIONER, "invalid");
 
         // An exception would be thrown for invalid "partitioner" setting
-        EXPECT_KAFKA_THROW(KafkaSyncProducer producer(props), RD_KAFKA_RESP_ERR__INVALID_ARG);
+        EXPECT_KAFKA_THROW(KafkaProducer producer(props), RD_KAFKA_RESP_ERR__INVALID_ARG);
     }
 }
 
-TEST(KafkaSyncProducer, RecordWithEmptyOrNullFields)
+TEST(KafkaProducer, RecordWithEmptyOrNullFields)
 {
     auto sendMessages = [](const Kafka::ProducerRecord& record, std::size_t repeat, const std::string& partitioner) {
-        Kafka::KafkaSyncProducer producer(KafkaTestUtility::GetKafkaClientCommonConfig()
+        Kafka::KafkaProducer producer(KafkaTestUtility::GetKafkaClientCommonConfig()
                                           .put(ProducerConfig::PARTITIONER, partitioner));
         producer.setLogLevel(Kafka::Log::Level::Crit);
         for (std::size_t i = 0; i < repeat; ++i) {
-            producer.send(record);
+            producer.syncSend(record);
         }
     };
 
@@ -319,10 +319,10 @@ TEST(KafkaSyncProducer, RecordWithEmptyOrNullFields)
     runTest(FieldType::Empty, "consistent",        false);
 }
 
-TEST(KafkaSyncProducer, ThreadCount)
+TEST(KafkaProducer, ThreadCount)
 {
     {
-        KafkaSyncProducer producer(KafkaTestUtility::GetKafkaClientCommonConfig());
+        KafkaProducer producer(KafkaTestUtility::GetKafkaClientCommonConfig());
         std::cout << "[" << Utility::getCurrentTime() << "] " << producer.name() << " started" << std::endl;
         std::cout << "[" << Utility::getCurrentTime() << "] librdkafka thread cnt[" << Utility::getLibRdKafkaThreadCount() << "]" << std::endl;
 
@@ -335,7 +335,7 @@ TEST(KafkaSyncProducer, ThreadCount)
     EXPECT_EQ(0, Utility::getLibRdKafkaThreadCount());
 }
 
-TEST(KafkaAsyncProducer, MessageDeliveryCallback)
+TEST(KafkaProducer, MessageDeliveryCallback)
 {
     // Prepare messages to test
     const std::vector<std::tuple<std::string, std::string, int>> messages = {
@@ -359,12 +359,12 @@ TEST(KafkaAsyncProducer, MessageDeliveryCallback)
             EXPECT_FALSE(error);
             EXPECT_EQ(topic, metadata.topic());
             EXPECT_EQ(partition, metadata.partition());
-            msgIdsSent.emplace(metadata.recordId());
+            msgIdsSent.emplace(*metadata.recordId());
         };
 
     // The producer would close anyway
     {
-        KafkaAsyncProducer producer(KafkaTestUtility::GetKafkaClientCommonConfig());
+        KafkaProducer producer(KafkaTestUtility::GetKafkaClientCommonConfig());
         for (const auto& msg: messages)
         {
             auto record = ProducerRecord(topic, partition,
@@ -385,7 +385,7 @@ TEST(KafkaAsyncProducer, MessageDeliveryCallback)
     }
 }
 
-TEST(KafkaAsyncProducer, DeliveryCallback_ManuallyPollEvents)
+TEST(KafkaProducer, DeliveryCallback_ManuallyPollEvents)
 {
     // Prepare messages to test
     const std::vector<std::tuple<std::string, std::string, int>> messages = {
@@ -409,14 +409,14 @@ TEST(KafkaAsyncProducer, DeliveryCallback_ManuallyPollEvents)
             EXPECT_FALSE(error);
             EXPECT_EQ(topic, metadata.topic());
             EXPECT_EQ(partition, metadata.partition());
-            msgIdsSent.emplace(metadata.recordId());
+            msgIdsSent.emplace(*metadata.recordId());
 
             EXPECT_EQ(std::this_thread::get_id(), appThreadId); // It would be polled by the same thread
         };
 
     // The producer would close anyway
     {
-        KafkaAsyncProducer producer(KafkaTestUtility::GetKafkaClientCommonConfig(), KafkaClient::EventsPollingOption::Manual);
+        KafkaProducer producer(KafkaTestUtility::GetKafkaClientCommonConfig(), KafkaClient::EventsPollingOption::Manual);
         for (const auto& msg: messages)
         {
             auto record = ProducerRecord(topic, partition,
@@ -445,7 +445,7 @@ TEST(KafkaAsyncProducer, DeliveryCallback_ManuallyPollEvents)
     }
 }
 
-TEST(KafkaAsyncProducer, NoBlockSendingWhileQueueIsFull_ManuallyPollEvents)
+TEST(KafkaProducer, NoBlockSendingWhileQueueIsFull_ManuallyPollEvents)
 {
     const Topic topic       = Utility::getRandomString();
     const auto  appThreadId = std::this_thread::get_id();
@@ -467,7 +467,7 @@ TEST(KafkaAsyncProducer, NoBlockSendingWhileQueueIsFull_ManuallyPollEvents)
     props.put(ProducerConfig::QUEUE_BUFFERING_MAX_MESSAGES, "1");
 
     // Maunally poll producer
-    KafkaAsyncProducer producer(props, KafkaClient::EventsPollingOption::Manual);
+    KafkaProducer producer(props, KafkaClient::EventsPollingOption::Manual);
 
     // Prepare messages to test
     const std::vector<std::pair<std::string, std::string>> messages = {
@@ -518,7 +518,7 @@ TEST(KafkaAsyncProducer, NoBlockSendingWhileQueueIsFull_ManuallyPollEvents)
     EXPECT_EQ(1, msgSentCnt);
 }
 
-TEST(KafkaAsyncProducer, TooLargeMessageForBroker)
+TEST(KafkaProducer, TooLargeMessageForBroker)
 {
     const Topic     topic     = Utility::getRandomString();
     const Partition partition = 0;
@@ -533,7 +533,7 @@ TEST(KafkaAsyncProducer, TooLargeMessageForBroker)
                        .put(ProducerConfig::MESSAGE_MAX_BYTES, "2000000") // Note: by default, the brokers only support messages no larger than 1M
                        .put(ProducerConfig::LINGER_MS,         "100");    // Here use a large value to make sure it's long enough to generate a large message-batch
 
-    KafkaAsyncProducer producer(props);
+    KafkaProducer producer(props);
 
     constexpr std::size_t MSG_NUM = 2000;
     std::size_t failedCount = 0;
@@ -553,7 +553,7 @@ TEST(KafkaAsyncProducer, TooLargeMessageForBroker)
     EXPECT_NE(0, failedCount);
 }
 
-TEST(KafkaAsyncProducer, CopyRecordValueWithinSend)
+TEST(KafkaProducer, CopyRecordValueWithinSend)
 {
     const Topic topic = Utility::getRandomString();
     KafkaTestUtility::CreateKafkaTopic(topic, 5, 3);
@@ -564,7 +564,7 @@ TEST(KafkaAsyncProducer, CopyRecordValueWithinSend)
     // Send messages (with option "ToCopyRecordValue")
     constexpr std::size_t MSG_NUM = 100;
     {
-        KafkaAsyncProducer producer(props);
+        KafkaProducer producer(props);
 
         for (std::size_t i = 0; i < MSG_NUM; ++i)
         {

--- a/tests/integration/TestTransaction.cc
+++ b/tests/integration/TestTransaction.cc
@@ -19,7 +19,7 @@ TEST(Transaction, CommitTransaction)
         auto props = KafkaTestUtility::GetKafkaClientCommonConfig();
         props.put(ProducerConfig::TRANSACTIONAL_ID, Utility::getRandomString());
 
-        KafkaAsyncProducer producer(props);
+        KafkaProducer producer(props);
         std::cout << "[" << Utility::getCurrentTime() << "] Producer created." << std::endl;
 
         producer.initTransactions(std::chrono::seconds(10));
@@ -153,7 +153,7 @@ TEST(Transaction, CatchException)
 
         auto props = KafkaTestUtility::GetKafkaClientCommonConfig();
 
-        KafkaAsyncProducer producer(props);
+        KafkaProducer producer(props);
 
         EXPECT_KAFKA_THROW(producer.initTransactions(), RD_KAFKA_RESP_ERR__NOT_CONFIGURED);
     }
@@ -164,7 +164,7 @@ TEST(Transaction, CatchException)
         auto props = KafkaTestUtility::GetKafkaClientCommonConfig();
         props.put(ProducerConfig::TRANSACTIONAL_ID, Utility::getRandomString());
 
-        KafkaAsyncProducer producer(props);
+        KafkaProducer producer(props);
 
         EXPECT_KAFKA_THROW(producer.beginTransaction(), RD_KAFKA_RESP_ERR__STATE);
     }
@@ -175,7 +175,7 @@ TEST(Transaction, CatchException)
         auto props = KafkaTestUtility::GetKafkaClientCommonConfig();
         props.put(ProducerConfig::TRANSACTIONAL_ID, Utility::getRandomString());
 
-        KafkaAsyncProducer producer(props);
+        KafkaProducer producer(props);
 
         producer.initTransactions();
 
@@ -189,7 +189,7 @@ TEST(Transaction, CatchException)
         auto props = KafkaTestUtility::GetKafkaClientCommonConfig();
         props.put(ProducerConfig::TRANSACTIONAL_ID, Utility::getRandomString());
 
-        KafkaAsyncProducer producer(props);
+        KafkaProducer producer(props);
 
         EXPECT_KAFKA_THROW(producer.abortTransaction(), RD_KAFKA_RESP_ERR__STATE);
     }
@@ -200,7 +200,7 @@ TEST(Transaction, CatchException)
         auto props = KafkaTestUtility::GetKafkaClientCommonConfig();
         props.put(ProducerConfig::TRANSACTIONAL_ID, Utility::getRandomString());
 
-        KafkaAsyncProducer producer(props);
+        KafkaProducer producer(props);
 
         producer.initTransactions();
 
@@ -213,7 +213,7 @@ TEST(Transaction, CatchException)
         auto props = KafkaTestUtility::GetKafkaClientCommonConfig();
         props.put(ProducerConfig::TRANSACTIONAL_ID, Utility::getRandomString());
 
-        KafkaAsyncProducer producer(props);
+        KafkaProducer producer(props);
 
         producer.initTransactions();
 
@@ -228,7 +228,7 @@ TEST(Transaction, CatchException)
         auto props = KafkaTestUtility::GetKafkaClientCommonConfig();
         props.put(ProducerConfig::TRANSACTIONAL_ID, Utility::getRandomString());
 
-        KafkaAsyncProducer producer(props);
+        KafkaProducer producer(props);
 
         producer.initTransactions();
 
@@ -248,8 +248,8 @@ TEST(Transaction, ContinueTheTransaction)
 
     // Start a producer to send the message, but fail to commit
     {
-        KafkaAsyncProducer producer(KafkaTestUtility::GetKafkaClientCommonConfig()
-                                      .put(ProducerConfig::TRANSACTIONAL_ID, transactionId));
+        KafkaProducer producer(KafkaTestUtility::GetKafkaClientCommonConfig()
+                                 .put(ProducerConfig::TRANSACTIONAL_ID, transactionId));
 
         producer.initTransactions();
 
@@ -268,7 +268,7 @@ TEST(Transaction, ContinueTheTransaction)
 
     // Start another producer, continue to send the message (with the same transaction.id)
     {
-        KafkaAsyncProducer producer(KafkaTestUtility::GetKafkaClientCommonConfig()
+        KafkaProducer producer(KafkaTestUtility::GetKafkaClientCommonConfig()
                                       .put(ProducerConfig::TRANSACTIONAL_ID, transactionId));
 
         producer.initTransactions();

--- a/tests/robustness/TestTransaction.cc
+++ b/tests/robustness/TestTransaction.cc
@@ -23,9 +23,9 @@ TEST(Transaction, DeliveryFailure)
     {
         auto record = ProducerRecord(topic, NullKey, Value(messageToSent.c_str(), messageToSent.size()));
 
-        KafkaAsyncProducer producer(KafkaTestUtility::GetKafkaClientCommonConfig()
-                                      .put(ProducerConfig::MESSAGE_TIMEOUT_MS, "3000")  // The delivery would fail in a short timeout
-                                      .put(ProducerConfig::TRANSACTIONAL_ID, transactionId));
+        KafkaProducer producer(KafkaTestUtility::GetKafkaClientCommonConfig()
+                                 .put(ProducerConfig::MESSAGE_TIMEOUT_MS, "3000")  // The delivery would fail in a short timeout
+                                 .put(ProducerConfig::TRANSACTIONAL_ID, transactionId));
         producer.setErrorCallback(KafkaTestUtility::DumpError);
 
         std::cout << "[" << Utility::getCurrentTime() << "] Producer created." << std::endl;

--- a/tests/unit/TestKafkaClientDefaultProperties.cc
+++ b/tests/unit/TestKafkaClientDefaultProperties.cc
@@ -45,7 +45,7 @@ bool checkProperties(const std::string& description, const Kafka::KafkaClient& c
 TEST(KafkaClient, KafkaProducerDefaultProperties)
 {
     {
-        Kafka::KafkaAsyncProducer producer(commonProps);
+        Kafka::KafkaProducer producer(commonProps);
 
         const KVMap expectedKVs =
         {
@@ -64,7 +64,7 @@ TEST(KafkaClient, KafkaProducerDefaultProperties)
             { Kafka::ProducerConfig::ENABLE_IDEMPOTENCE,            "false"     },
         };
 
-        EXPECT_TRUE(checkProperties("KafkaAsyncProducer", producer, expectedKVs));
+        EXPECT_TRUE(checkProperties("KafkaProducer", producer, expectedKVs));
     }
 
     KafkaTestUtility::PrintDividingLine();
@@ -72,7 +72,7 @@ TEST(KafkaClient, KafkaProducerDefaultProperties)
     {
         auto props = commonProps.put(Kafka::ProducerConfig::ENABLE_IDEMPOTENCE, "true");
 
-        Kafka::KafkaAsyncProducer producer(props);
+        Kafka::KafkaProducer producer(props);
 
         const KVMap expectedKVs =
         {
@@ -80,22 +80,7 @@ TEST(KafkaClient, KafkaProducerDefaultProperties)
             { Kafka::ProducerConfig::ENABLE_IDEMPOTENCE,  "true" },
         };
 
-        EXPECT_TRUE(checkProperties("KafkaAsyncProducer(idempotence enabled)", producer, expectedKVs));
-    }
-
-    KafkaTestUtility::PrintDividingLine();
-
-    {
-        Kafka::KafkaSyncProducer producer(commonProps);
-        const KVMap expectedKVs =
-        {
-            { Kafka::ProducerConfig::LINGER_MS, "0" },
-        };
-
-        EXPECT_TRUE(checkProperties("KafkaSyncProducer", producer, expectedKVs));
-
-        // Query for an invalid property
-        EXPECT_FALSE(producer.getProperty("invalid"));
+        EXPECT_TRUE(checkProperties("KafkaProducer(idempotence enabled)", producer, expectedKVs));
     }
 }
 

--- a/tests/unit/TestProducerRecord.cc
+++ b/tests/unit/TestProducerRecord.cc
@@ -19,13 +19,13 @@ TEST(ProducerRecord, WithSpecificPartition)
     record.headers().emplace_back("hk1", Kafka::Header::Value(headerValue1.c_str(), headerValue1.size()));
     record.headers().emplace_back("hk2", Kafka::Header::Value(headerValue2.c_str(), headerValue2.size()));
 
-    EXPECT_EQ("topic1-1:0, headers[hk1:hv1,hk2:hv2], key1/hello world", record.toString());
+    EXPECT_EQ("topic1-1: headers[hk1:hv1,hk2:hv2], key1/hello world", record.toString());
 
     std::string payload2 = "it has been changed";
     record.setValue(Kafka::Value(payload2.c_str(), payload2.size()));
     record.headers().clear();
 
-    EXPECT_EQ("topic1-1:0, key1/it has been changed", record.toString());
+    EXPECT_EQ("topic1-1: key1/it has been changed", record.toString());
 }
 
 TEST(ProducerRecord, WithNoSpecificPartition)

--- a/tests/utils/TestUtility.h
+++ b/tests/utils/TestUtility.h
@@ -179,7 +179,7 @@ WaitUntil(const std::function<bool()>& checkDone, std::chrono::milliseconds time
 inline std::vector<Kafka::Producer::RecordMetadata>
 ProduceMessages(const std::string& topic, int partition, const std::vector<std::tuple<Kafka::Headers, std::string, std::string>>& msgs)
 {
-    Kafka::KafkaSyncProducer producer(GetKafkaClientCommonConfig());
+    Kafka::KafkaProducer producer(GetKafkaClientCommonConfig());
     producer.setLogLevel(Kafka::Log::Level::Crit);
 
     std::vector<Kafka::Producer::RecordMetadata> ret;
@@ -187,7 +187,7 @@ ProduceMessages(const std::string& topic, int partition, const std::vector<std::
     {
         auto record = Kafka::ProducerRecord(topic, partition, Kafka::Key(std::get<1>(msg).c_str(), std::get<1>(msg).size()), Kafka::Value(std::get<2>(msg).c_str(), std::get<2>(msg).size()));
         record.headers() = std::get<0>(msg);
-        auto metadata = producer.send(record);
+        auto metadata = producer.syncSend(record);
         ret.emplace_back(metadata);
     }
 

--- a/tools/KafkaConsoleProducer.cc
+++ b/tools/KafkaConsoleProducer.cc
@@ -107,7 +107,7 @@ int main (int argc, char **argv)
 
     // Create a sync-send producer
     Kafka::KafkaClient::setGlobalLogger(Kafka::Logger());
-    Kafka::KafkaSyncProducer producer(props);
+    Kafka::KafkaProducer producer(props);
 
     auto startPromptLine = []() { std::cout << "> "; };
 
@@ -126,7 +126,7 @@ int main (int argc, char **argv)
             std::cout << "Current Local Time [" << Kafka::Utility::getCurrentTime() << "]" << std::endl;
 
             // Note: might throw exceptions if with unknown topic, unknown partition, invalid message length, etc.
-            auto metadata = producer.send(record);
+            auto metadata = producer.syncSend(record);
 
             std::cout << "Just Sent Key[" << metadata.keySize()   << " B]/Value["  << metadata.valueSize() << " B]"
                 << " ==> " << metadata.topic() << "-" << std::to_string(metadata.partition()) << "@" <<  (metadata.offset() ? std::to_string(*metadata.offset()) : "NA")


### PR DESCRIPTION
1. Unified `KafkaProducer` for `KafkaAsyncProducer` & `KafkaSyncProducer`
    * New interface `syncSend` for synchronous operation
2. `Producer::Record::Id` is optional for both `Producer::Record` and `Producer::RecordMetadata`