### PR TITLE
Make the project more ExternalProject-friendly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,13 @@ cmake_minimum_required(VERSION "3.8")
 
 project("Modern C++ Kafka API" VERSION 1.0.0)
 
-include(CTest)
+get_property(parent_directory DIRECTORY PROPERTY PARENT_DIRECTORY)
+if(NOT parent_directory)
+    set(cppkafka_master_project ON)
+endif()
+
+option(CPPKAFKA_ENABLE_TESTS "Generate the test targets" ${cppkafka_master_project})
+
 include(CheckCXXCompilerFlag)
 include(CMakePushCheckState)
 
@@ -250,7 +256,14 @@ else ()
     endif ()
 
     add_subdirectory("include")
-    add_subdirectory("tests")
-    add_subdirectory("tools")
-    add_subdirectory("examples")
+
+    if (CPPKAFKA_ENABLE_TESTS)
+        include(CTest)
+        add_subdirectory("tests")
+    endif()
+
+    if (cppkafka_master_project)
+        add_subdirectory("tools")
+        add_subdirectory("examples")
+    endif()
 endif ()

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -2,7 +2,7 @@ project(modern-cpp-kafka-api)
 
 add_library(${PROJECT_NAME} INTERFACE)
 
-target_include_directories(${PROJECT_NAME} INTERFACE "./")
+target_include_directories(${PROJECT_NAME} INTERFACE ${CMAKE_CURRENT_LIST_DIR})
 
 #---------------------------
 # librdkafka

--- a/include/kafka/AdminClient.h
+++ b/include/kafka/AdminClient.h
@@ -1,14 +1,14 @@
 #pragma once
 
-#include "kafka/Project.h"
+#include <kafka/Project.h>
 
-#include "kafka/AdminClientConfig.h"
-#include "kafka/AdminCommon.h"
-#include "kafka/Error.h"
-#include "kafka/KafkaClient.h"
-#include "kafka/RdKafkaHelper.h"
+#include <kafka/AdminClientConfig.h>
+#include <kafka/AdminCommon.h>
+#include <kafka/Error.h>
+#include <kafka/KafkaClient.h>
+#include <kafka/RdKafkaHelper.h>
 
-#include "librdkafka/rdkafka.h"
+#include <librdkafka/rdkafka.h>
 
 #include <array>
 #include <cassert>

--- a/include/kafka/AdminClientConfig.h
+++ b/include/kafka/AdminClientConfig.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include "kafka/Project.h"
+#include <kafka/Project.h>
 
-#include "kafka/Properties.h"
+#include <kafka/Properties.h>
 
 
 namespace KAFKA_API::clients::admin {

--- a/include/kafka/AdminCommon.h
+++ b/include/kafka/AdminCommon.h
@@ -1,9 +1,9 @@
 #pragma once
 
-#include "kafka/Project.h"
+#include <kafka/Project.h>
 
-#include "kafka/Error.h"
-#include "kafka/Types.h"
+#include <kafka/Error.h>
+#include <kafka/Types.h>
 
 
 namespace KAFKA_API::clients::admin {

--- a/include/kafka/BrokerMetadata.h
+++ b/include/kafka/BrokerMetadata.h
@@ -1,11 +1,11 @@
 #pragma once
 
-#include "kafka/Project.h"
+#include <kafka/Project.h>
 
-#include "kafka/KafkaException.h"
-#include "kafka/Types.h"
+#include <kafka/KafkaException.h>
+#include <kafka/Types.h>
 
-#include "librdkafka/rdkafka.h"
+#include <librdkafka/rdkafka.h>
 
 #include <map>
 #include <vector>

--- a/include/kafka/ConsumerCommon.h
+++ b/include/kafka/ConsumerCommon.h
@@ -1,12 +1,12 @@
 #pragma once
 
-#include "kafka/Project.h"
+#include <kafka/Project.h>
 
-#include "kafka/Error.h"
-#include "kafka/RdKafkaHelper.h"
-#include "kafka/Types.h"
+#include <kafka/Error.h>
+#include <kafka/RdKafkaHelper.h>
+#include <kafka/Types.h>
 
-#include "librdkafka/rdkafka.h"
+#include <librdkafka/rdkafka.h>
 
 #include <functional>
 

--- a/include/kafka/ConsumerConfig.h
+++ b/include/kafka/ConsumerConfig.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include "kafka/Project.h"
+#include <kafka/Project.h>
 
-#include "kafka/Properties.h"
+#include <kafka/Properties.h>
 
 
 namespace KAFKA_API::clients::consumer {

--- a/include/kafka/ConsumerRecord.h
+++ b/include/kafka/ConsumerRecord.h
@@ -1,13 +1,13 @@
 #pragma once
 
-#include "kafka/Project.h"
+#include <kafka/Project.h>
 
-#include "kafka/Error.h"
-#include "kafka/Header.h"
-#include "kafka/Timestamp.h"
-#include "kafka/Types.h"
+#include <kafka/Error.h>
+#include <kafka/Header.h>
+#include <kafka/Timestamp.h>
+#include <kafka/Types.h>
 
-#include "librdkafka/rdkafka.h"
+#include <librdkafka/rdkafka.h>
 
 #include <sstream>
 

--- a/include/kafka/Error.h
+++ b/include/kafka/Error.h
@@ -1,10 +1,10 @@
 #pragma once
 
-#include "kafka/Project.h"
+#include <kafka/Project.h>
 
-#include "kafka/RdKafkaHelper.h"
+#include <kafka/RdKafkaHelper.h>
 
-#include "librdkafka/rdkafka.h"
+#include <librdkafka/rdkafka.h>
 
 #include <string>
 #include <system_error>

--- a/include/kafka/Header.h
+++ b/include/kafka/Header.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include "kafka/Project.h"
+#include <kafka/Project.h>
 
-#include "kafka/Types.h"
+#include <kafka/Types.h>
 
 #include <algorithm>
 #include <string>

--- a/include/kafka/KafkaClient.h
+++ b/include/kafka/KafkaClient.h
@@ -1,16 +1,16 @@
 #pragma once
 
-#include "kafka/Project.h"
+#include <kafka/Project.h>
 
-#include "kafka/BrokerMetadata.h"
-#include "kafka/Error.h"
-#include "kafka/KafkaException.h"
-#include "kafka/Log.h"
-#include "kafka/Properties.h"
-#include "kafka/RdKafkaHelper.h"
-#include "kafka/Types.h"
+#include <kafka/BrokerMetadata.h>
+#include <kafka/Error.h>
+#include <kafka/KafkaException.h>
+#include <kafka/Log.h>
+#include <kafka/Properties.h>
+#include <kafka/RdKafkaHelper.h>
+#include <kafka/Types.h>
 
-#include "librdkafka/rdkafka.h"
+#include <librdkafka/rdkafka.h>
 
 #include <atomic>
 #include <cassert>

--- a/include/kafka/KafkaConsumer.h
+++ b/include/kafka/KafkaConsumer.h
@@ -1,14 +1,14 @@
 #pragma once
 
-#include "kafka/Project.h"
+#include <kafka/Project.h>
 
-#include "kafka/ConsumerCommon.h"
-#include "kafka/ConsumerConfig.h"
-#include "kafka/ConsumerRecord.h"
-#include "kafka/Error.h"
-#include "kafka/KafkaClient.h"
+#include <kafka/ConsumerCommon.h>
+#include <kafka/ConsumerConfig.h>
+#include <kafka/ConsumerRecord.h>
+#include <kafka/Error.h>
+#include <kafka/KafkaClient.h>
 
-#include "librdkafka/rdkafka.h"
+#include <librdkafka/rdkafka.h>
 
 #include <algorithm>
 #include <cassert>

--- a/include/kafka/KafkaException.h
+++ b/include/kafka/KafkaException.h
@@ -1,12 +1,12 @@
 #pragma once
 
-#include "kafka/Project.h"
+#include <kafka/Project.h>
 
-#include "kafka/Error.h"
-#include "kafka/RdKafkaHelper.h"
-#include "kafka/Utility.h"
+#include <kafka/Error.h>
+#include <kafka/RdKafkaHelper.h>
+#include <kafka/Utility.h>
 
-#include "librdkafka/rdkafka.h"
+#include <librdkafka/rdkafka.h>
 
 #include <chrono>
 #include <exception>

--- a/include/kafka/KafkaProducer.h
+++ b/include/kafka/KafkaProducer.h
@@ -1,16 +1,16 @@
 #pragma once
 
-#include "kafka/Project.h"
+#include <kafka/Project.h>
 
-#include "kafka/ConsumerCommon.h"
-#include "kafka/KafkaClient.h"
-#include "kafka/ProducerCommon.h"
-#include "kafka/ProducerConfig.h"
-#include "kafka/ProducerRecord.h"
-#include "kafka/Timestamp.h"
-#include "kafka/Types.h"
+#include <kafka/ConsumerCommon.h>
+#include <kafka/KafkaClient.h>
+#include <kafka/ProducerCommon.h>
+#include <kafka/ProducerConfig.h>
+#include <kafka/ProducerRecord.h>
+#include <kafka/Timestamp.h>
+#include <kafka/Types.h>
 
-#include "librdkafka/rdkafka.h"
+#include <librdkafka/rdkafka.h>
 
 #include <cassert>
 #include <condition_variable>

--- a/include/kafka/Log.h
+++ b/include/kafka/Log.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include "kafka/Project.h"
+#include <kafka/Project.h>
 
-#include "kafka/Utility.h"
+#include <kafka/Utility.h>
 
 #include <cassert>
 #include <functional>

--- a/include/kafka/ProducerCommon.h
+++ b/include/kafka/ProducerCommon.h
@@ -1,13 +1,13 @@
 #pragma once
 
-#include "kafka/Project.h"
+#include <kafka/Project.h>
 
-#include "kafka/ProducerRecord.h"
-#include "kafka/RdKafkaHelper.h"
-#include "kafka/Timestamp.h"
-#include "kafka/Types.h"
+#include <kafka/ProducerRecord.h>
+#include <kafka/RdKafkaHelper.h>
+#include <kafka/Timestamp.h>
+#include <kafka/Types.h>
 
-#include "librdkafka/rdkafka.h"
+#include <librdkafka/rdkafka.h>
 
 #include <functional>
 #include <memory>

--- a/include/kafka/ProducerConfig.h
+++ b/include/kafka/ProducerConfig.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include "kafka/Project.h"
+#include <kafka/Project.h>
 
-#include "kafka/Types.h"
+#include <kafka/Types.h>
 
 
 namespace KAFKA_API::clients::producer {

--- a/include/kafka/ProducerRecord.h
+++ b/include/kafka/ProducerRecord.h
@@ -1,11 +1,11 @@
 #pragma once
 
-#include "kafka/Project.h"
+#include <kafka/Project.h>
 
-#include "kafka/Header.h"
-#include "kafka/Types.h"
+#include <kafka/Header.h>
+#include <kafka/Types.h>
 
-#include "librdkafka/rdkafka.h"
+#include <librdkafka/rdkafka.h>
 
 
 namespace KAFKA_API::clients::producer {

--- a/include/kafka/Properties.h
+++ b/include/kafka/Properties.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include "kafka/Project.h"
+#include <kafka/Project.h>
 
-#include "kafka/Types.h"
+#include <kafka/Types.h>
 
 #include <algorithm>
 #include <map>

--- a/include/kafka/RdKafkaHelper.h
+++ b/include/kafka/RdKafkaHelper.h
@@ -1,10 +1,10 @@
 #pragma once
 
-#include "kafka/Project.h"
+#include <kafka/Project.h>
 
-#include "kafka/Types.h"
+#include <kafka/Types.h>
 
-#include "librdkafka/rdkafka.h"
+#include <librdkafka/rdkafka.h>
 
 #include <memory>
 

--- a/include/kafka/Timestamp.h
+++ b/include/kafka/Timestamp.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include "kafka/Project.h"
+#include <kafka/Project.h>
 
-#include "librdkafka/rdkafka.h"
+#include <librdkafka/rdkafka.h>
 
 #include <cassert>
 #include <chrono>

--- a/include/kafka/Types.h
+++ b/include/kafka/Types.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "kafka/Project.h"
+#include <kafka/Project.h>
 
 #include <algorithm>
 #include <cctype>

--- a/include/kafka/Utility.h
+++ b/include/kafka/Utility.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include "kafka/Project.h"
+#include <kafka/Project.h>
 
-#include "librdkafka/rdkafka.h"
+#include <librdkafka/rdkafka.h>
 
 #include <chrono>
 #include <iomanip>

--- a/include/kafka/addons/KafkaMetrics.h
+++ b/include/kafka/addons/KafkaMetrics.h
@@ -1,11 +1,11 @@
 #pragma once
 
-#include "kafka/Project.h"
+#include <kafka/Project.h>
 
 // https://github.com/Tencent/rapidjson/releases/tag/v1.1.0
-#include "rapidjson/document.h"
-#include "rapidjson/stringbuffer.h"
-#include "rapidjson/writer.h"
+#include <rapidjson/document.h>
+#include <rapidjson/stringbuffer.h>
+#include <rapidjson/writer.h>
 
 #include <algorithm>
 #include <iostream>

--- a/include/kafka/addons/KafkaRecoverableProducer.h
+++ b/include/kafka/addons/KafkaRecoverableProducer.h
@@ -1,10 +1,10 @@
 #pragma once
 
-#include "kafka/Project.h"
+#include <kafka/Project.h>
 
-#include "kafka/KafkaClient.h"
-#include "kafka/KafkaProducer.h"
-#include "kafka/Types.h"
+#include <kafka/KafkaClient.h>
+#include <kafka/KafkaProducer.h>
+#include <kafka/Types.h>
 
 #include <deque>
 #include <mutex>

--- a/include/kafka/addons/UnorderedOffsetCommitQueue.h
+++ b/include/kafka/addons/UnorderedOffsetCommitQueue.h
@@ -1,9 +1,9 @@
 #pragma once
 
-#include "kafka/Project.h"
+#include <kafka/Project.h>
 
-#include "kafka/KafkaClient.h"
-#include "kafka/Types.h"
+#include <kafka/KafkaClient.h>
+#include <kafka/Types.h>
 
 #include <deque>
 #include <vector>


### PR DESCRIPTION
There might be more work to do with modernizing CMake, but this is a minimal change set to make it work properly with ExternalProject (and therefore FetchContent).

Here's my working example which works with statically-built librdkafka located in `~/bin/librdkafka`

```
FetchContent_Declare(cppkafka
    URL      https://github.com/jm4R/modern-cpp-kafka/archive/refs/heads/friendly-cmake.zip
    URL_HASH SHA256=e15fc6f79419325c3f9bdfa1e867c52a8f4ab0b1e05c254e93a51cfff36c3f5f
)
SET(ENV{LIBRDKAFKA_ROOT} "$ENV{HOME}/bin/librdkafka")
FetchContent_MakeAvailable(cppkafka)
find_package(OpenSSL REQUIRED)
find_package(ZLIB REQUIRED)
add_library(rdkafka-cpp INTERFACE)
target_link_libraries(rdkafka-cpp INTERFACE
    ZLIB::ZLIB
    OpenSSL::SSL
    OpenSSL::Crypto
    modern-cpp-kafka-api
    dl
)
```

After that one can just link to `rdkafka-cpp` and it works. The target (when included as external) doesn't compile anything (like tests & examples), just uses provided headers.

Fixes #119 