### PR TITLE
add support to none-ASCII string in ConstBuffer

### DIFF
--- a/include/kafka/Types.h
+++ b/include/kafka/Types.h
@@ -55,6 +55,28 @@ public:
 
         return oss.str();
     }
+
+    /**
+     * @brief return an UTF-8 encoded string.
+     * 
+     * @return std::string 
+     */
+    std::string toUtf8String() const
+    {
+        if (_size == 0) return _data ? "[empty]" : "[null]";
+
+        std::ostringstream oss;
+
+        auto getStr = [&oss](const unsigned char c)
+        { 
+            oss << c;
+        };
+        
+        const auto *beg = static_cast<const unsigned char *>(_data);
+        std::for_each(beg, beg + _size, getStr);
+
+        return oss.str();
+    }
 private:
     const void* _data;
     std::size_t _size;


### PR DESCRIPTION
This PR add an new feature: support converting None-ASCII value to std::string in the right way.

How I find the problem:
When I'm trying to get ConsumerRecord.value() and convert it to std::string, I found that it only support ASCII-characters. 

Solution:
I add an function named toUTF8String() in  KAFKA_API::ConstBuffer to support convert contents in buffer to UTF-8 string.