### PR TITLE
Added #undef min in Log.h

### DIFF
--- a/include/kafka/Log.h
+++ b/include/kafka/Log.h
@@ -10,6 +10,7 @@
 #include <functional>
 #include <iostream>
 
+#undef min
 
 namespace KAFKA_API {
 


### PR DESCRIPTION
While using modern cpp kafka with Windows.h there is a conflict with "std::min" (probably there is a #define min clause in Windows libraries). Adding "#undef min" to include/kafka/Log.h solves problem and allows to use windows libraries.