### PR TITLE
Wrap std::min in parens to avoid conflicts with macros

### DIFF
--- a/include/kafka/Log.h
+++ b/include/kafka/Log.h
@@ -32,7 +32,7 @@ struct Log
         static const std::vector<std::string> levelNames = {"EMERG", "ALERT", "CRIT", "ERR", "WARNING", "NOTICE", "INFO", "DEBUG", "INVALID"};
         static const std::size_t              maxIndex   = levelNames.size() - 1;
 
-        return levelNames[std::min(level, maxIndex)];
+        return levelNames[(std::min)(level, maxIndex)];
     }
 };
 
@@ -57,7 +57,7 @@ public:
         auto cnt = std::snprintf(_wptr, capacity(), format, args...); // returns number of characters written if successful (not including '\0')
         if (cnt > 0)
         {
-            _wptr = std::min(_wptr + cnt, _buf.data() + MAX_CAPACITY - 1);
+            _wptr = (std::min)(_wptr + cnt, _buf.data() + MAX_CAPACITY - 1);
         }
         return *this;
     }

--- a/tests/unit/TestUnorderedOffsetCommitQueue.cc
+++ b/tests/unit/TestUnorderedOffsetCommitQueue.cc
@@ -134,7 +134,7 @@ auto checkTimeMsConsumedToSortOffsets(std::size_t testNum, std::size_t step)
     std::mt19937 g(rd());
     for (std::size_t iBegin = 0; iBegin < ackSequence.size(); iBegin += step)
     {
-        std::size_t iEnd = std::min(iBegin + step, ackSequence.size());
+        std::size_t iEnd = (std::min)(iBegin + step, ackSequence.size());
         std::shuffle(ackSequence.begin() + static_cast<int64_t>(iBegin), ackSequence.begin() + static_cast<int64_t>(iEnd), g);
     }
 


### PR DESCRIPTION
Try to fix https://github.com/morganstanley/modern-cpp-kafka/issues/165