### PR TITLE
Interceptor for broker's state

### DIFF
--- a/.github/workflows/kafka_api_bazel_build.yml
+++ b/.github/workflows/kafka_api_bazel_build.yml
@@ -9,7 +9,7 @@ on:
 env:
   KAFKA_SRC_LINK: https://archive.apache.org/dist/kafka/3.3.1/kafka_2.13-3.3.1.tgz
   CPU_CORE_NUM:   2
-  LIBRDKAFKA_TAG: v1.9.2
+  LIBRDKAFKA_TAG: v2.0.2
 
 jobs:
   kafka-api-bazel-build:

--- a/.github/workflows/kafka_api_ci_tests.yml
+++ b/.github/workflows/kafka_api_ci_tests.yml
@@ -9,7 +9,7 @@ on:
 env:
   KAFKA_SRC_LINK: https://archive.apache.org/dist/kafka/3.3.1/kafka_2.13-3.3.1.tgz
   CPU_CORE_NUM:   2
-  LIBRDKAFKA_TAG: v1.9.2
+  LIBRDKAFKA_TAG: v2.0.2
   BUILD_SUB_DIR:  builds/sub-build
 
 jobs:

--- a/.github/workflows/kafka_api_demo_conan_build.yml
+++ b/.github/workflows/kafka_api_demo_conan_build.yml
@@ -26,19 +26,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Prepare (non-windows)
-        if: ${{!contains(matrix.os, 'windows')}}
+      - name: Prepare
         run: |
-          if [[ ${OS_VERSION} == 'macos'* ]]; then
-            brew install conan
-          else
-            pip3 install conan
-          fi
-
-      - name: Prepare (windows)
-        if: ${{contains(matrix.os, 'windows')}}
-        run: |
-          pip3 install conan
+          pip3 install conan==1.59.0
 
       - name: Build (non-windows)
         if: ${{!contains(matrix.os, 'windows')}}
@@ -52,11 +42,8 @@ jobs:
           cmake .. -G "Unix Makefiles"
           cmake --build .
 
-          bin/kafka_sync_producer
-          bin/kafka_async_producer_copy_payload
-          bin/kafka_async_producer_not_copy_payload
-          bin/kafka_auto_commit_consumer
-          bin/kafka_manual_commit_consumer
+          bin/kafka_producer
+          bin/kafka_consumer
 
       - name: Build (windows)
         if: contains(matrix.os, 'windows')
@@ -70,9 +57,6 @@ jobs:
           cmake ..
           cmake --build .
 
-          bin/kafka_sync_producer.exe
-          bin/kafka_async_producer_copy_payload.exe
-          bin/kafka_async_producer_not_copy_payload.exe
-          bin/kafka_auto_commit_consumer.exe
-          bin/kafka_manual_commit_consumer.exe
+          bin/kafka_producer.exe
+          bin/kafka_consumer.exe
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ About the *Modern C++ Kafka API*
 
 The [modern-cpp-kafka API](http://opensource.morganstanley.com/modern-cpp-kafka/doxygen/annotated.html) is a layer of ***C++*** wrapper based on [librdkafka](https://github.com/confluentinc/librdkafka) (the ***C*** part only), with high quality, but more friendly to users.
 
-- By now, [modern-cpp-kafka](https://github.com/morganstanley/modern-cpp-kafka) is compatible with [librdkafka v1.9.2](https://github.com/confluentinc/librdkafka/releases/tag/v1.9.2).
+- By now, [modern-cpp-kafka](https://github.com/morganstanley/modern-cpp-kafka) is compatible with [librdkafka v2.0.2](https://github.com/confluentinc/librdkafka/releases/tag/v2.0.2).
 
 
 ```

--- a/demo_projects_for_build/conan_build/CMakeLists.txt
+++ b/demo_projects_for_build/conan_build/CMakeLists.txt
@@ -7,22 +7,11 @@ set(CMAKE_CXX_STANDARD_REQUIRED True)
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup()
 
-# Target: kafka_sync_producer
-add_executable("kafka_sync_producer" "../../examples/kafka_sync_producer.cc")
-target_link_libraries("kafka_sync_producer" ${CONAN_LIBS})
+# Target: kafka_producer
+add_executable("kafka_producer" "../../examples/kafka_async_producer_not_copy_payload.cc")
+target_link_libraries("kafka_producer" ${CONAN_LIBS})
 
-# Target: kafka_async_producer_copy_payload
-add_executable("kafka_async_producer_copy_payload" "../../examples/kafka_async_producer_copy_payload.cc")
-target_link_libraries("kafka_async_producer_copy_payload" ${CONAN_LIBS})
+# Target: kafka_consumer
+add_executable("kafka_consumer" "../../examples/kafka_auto_commit_consumer.cc")
+target_link_libraries("kafka_consumer" ${CONAN_LIBS})
 
-# Target: kafka_async_producer_not_copy_payload
-add_executable("kafka_async_producer_not_copy_payload" "../../examples/kafka_async_producer_not_copy_payload.cc")
-target_link_libraries("kafka_async_producer_not_copy_payload" ${CONAN_LIBS})
-
-# Target: kafka_auto_commit_consumer
-add_executable("kafka_auto_commit_consumer" "../../examples/kafka_auto_commit_consumer.cc")
-target_link_libraries("kafka_auto_commit_consumer" ${CONAN_LIBS})
-
-# Target: kafka_manual_commit_consumer
-add_executable("kafka_manual_commit_consumer" "../../examples/kafka_manual_commit_consumer.cc")
-target_link_libraries("kafka_manual_commit_consumer" ${CONAN_LIBS})

--- a/demo_projects_for_build/conan_build/conanfile.txt
+++ b/demo_projects_for_build/conan_build/conanfile.txt
@@ -1,5 +1,5 @@
 [requires]
-modern-cpp-kafka/2022.06.15
+modern-cpp-kafka/2023.01.05
 
 [generators]
 cmake

--- a/include/kafka/Interceptors.h
+++ b/include/kafka/Interceptors.h
@@ -16,32 +16,47 @@ public:
     /**
     * Callback type for thread-start interceptor.
     */
-    using ThreadStartCallback = std::function<void(const std::string&, const std::string&)>;
+    using ThreadStartCb = std::function<void(const std::string&, const std::string&)>;
 
     /**
     * Callback type for thread-exit interceptor.
     */
-    using ThreadExitCallback  = std::function<void(const std::string&, const std::string&)>;
+    using ThreadExitCb  = std::function<void(const std::string&, const std::string&)>;
+
+    /**
+    * Callback type for broker-state-change interceptor.
+    */
+    using BrokerStateChangeCb = std::function<void(int, const std::string&, const std::string&, int, const std::string&)>;
 
     /**
     * Set interceptor for thread start.
     */
-    Interceptors& onThreadStart(ThreadStartCallback cb) { _valid = true; _threadStartCb = std::move(cb); return *this; }
+    Interceptors& onThreadStart(ThreadStartCb cb) { _valid = true; _threadStartCb = std::move(cb); return *this; }
 
     /**
     * Set interceptor for thread exit.
     */
-    Interceptors& onThreadExit(ThreadExitCallback cb)   { _valid = true; _threadExitCb = std::move(cb);  return *this; }
+    Interceptors& onThreadExit(ThreadExitCb cb)   { _valid = true; _threadExitCb = std::move(cb);  return *this; }
+
+    /**
+    * Set interceptor for broker state change.
+    */
+    Interceptors& onBrokerStateChange(BrokerStateChangeCb cb) { _valid = true; _brokerStateChangeCb = std::move(cb);  return *this; }
 
     /**
     * Get interceptor for thread start.
     */
-    ThreadStartCallback onThreadStart() const { return _threadStartCb; }
+    ThreadStartCb onThreadStart() const { return _threadStartCb; }
 
     /**
     * Get interceptor for thread exit.
     */
-    ThreadExitCallback  onThreadExit()  const { return _threadExitCb; }
+    ThreadExitCb  onThreadExit()  const { return _threadExitCb; }
+
+    /**
+    * Get interceptor for broker state change.
+    */
+    BrokerStateChangeCb onBrokerStateChange() const { return _brokerStateChangeCb; }
 
     /**
     * Check if there's no interceptor.
@@ -49,9 +64,11 @@ public:
     bool empty() const { return !_valid; }
 
 private:
-    ThreadStartCallback _threadStartCb;
-    ThreadExitCallback  _threadExitCb;
-    bool                _valid  = false;
+    ThreadStartCb       _threadStartCb;
+    ThreadExitCb        _threadExitCb;
+    BrokerStateChangeCb _brokerStateChangeCb;
+
+    bool _valid  = false;
 };
 
 } } // end of KAFKA_API::clients


### PR DESCRIPTION
This PR would be pending for a while, until a new `librdkafka` release is available (with https://github.com/edenhill/librdkafka/pull/4043)

Test output,
```
[ RUN      ] KafkaConsumer.BasicPoll
[2022-11-01 22:19:17.786359] kafka::Topic[6f794424-c55fa042] would be used
[2022-11-01 22:19:23.136371] CreateKafkaTopic: create topic[6f794424-c55fa042] with numPartitions[5], replicationFactor[3]. Result: Success
Broker[-1 - plaintext://GroupCoordinator:0] ==> INIT
Broker[-1 - plaintext://:0] ==> INIT
Broker[-1 - plaintext://127.0.0.1:40091] ==> INIT
Broker[-1 - plaintext://127.0.0.1:40092] ==> INIT
Broker[-1 - plaintext://127.0.0.1:40093] ==> INIT
[2022-11-01 22:19:28.138534]NOTICE KafkaConsumer[d86cbe85-bce18c70] initialized with properties[auto.commit.interval.ms=0|bootstrap.servers=127.0.0.1:40091,127.0.0.1:40092,127.0.0.1:40093|client.id=d86cbe85-bce18c70|enable.auto.commit=true|enable.auto.offset.store=true|group.id=d86d20f5-e1acece|log_level=5|max.poll.records=500]
[2022-11-01 22:19:28.138573] KafkaConsumer[d86cbe85-bce18c70] started
Broker[-1 - plaintext://127.0.0.1:40092] ==> TRY_CONNECT
Broker[-1 - plaintext://127.0.0.1:40092] ==> CONNECT
Broker[-1 - plaintext://127.0.0.1:40092] ==> APIVERSION_QUERY
Broker[-1 - plaintext://127.0.0.1:40092] ==> UP
Broker[1 - plaintext://127.0.0.1:40092] ==> UPDATE
Broker[1 - plaintext://127.0.0.1:40092] ==> UP
Broker[2 - plaintext://GroupCoordinator:0] ==> TRY_CONNECT
Broker[2 - plaintext://GroupCoordinator:0] ==> CONNECT
Broker[2 - plaintext://GroupCoordinator:0] ==> APIVERSION_QUERY
Broker[2 - plaintext://GroupCoordinator:0] ==> UP
[2022-11-01 22:19:31.413118]NOTICE KafkaConsumer[d86cbe85-bce18c70] re-balance event triggered[ASSIGN_PARTITIONS], cooperative[disabled], topic-partitions[6f794424-c55fa042-0,6f794424-c55fa042-1,6f794424-c55fa042-2,6f794424-c55fa042-3,6f794424-c55fa042-4]
[2022-11-01 22:19:31.413542] assigned partitions: 6f794424-c55fa042-0,6f794424-c55fa042-1,6f794424-c55fa042-2,6f794424-c55fa042-3,6f794424-c55fa042-4
[2022-11-01 22:19:31.413569]NOTICE KafkaConsumer[d86cbe85-bce18c70] subscribed, topics[6f794424-c55fa042]
Broker[0 - plaintext://127.0.0.1:40091] ==> TRY_CONNECT
Broker[2 - plaintext://127.0.0.1:40093] ==> TRY_CONNECT
Broker[0 - plaintext://127.0.0.1:40091] ==> CONNECT
Broker[2 - plaintext://127.0.0.1:40093] ==> CONNECT
Broker[0 - plaintext://127.0.0.1:40091] ==> APIVERSION_QUERY
Broker[2 - plaintext://127.0.0.1:40093] ==> APIVERSION_QUERY
Broker[0 - plaintext://127.0.0.1:40091] ==> UP
Broker[2 - plaintext://127.0.0.1:40093] ==> UP
[2022-11-01 22:19:32.415571] KafkaConsumer[d86cbe85-bce18c70] polled 0 messages
[2022-11-01 22:19:32.415622] Consumer get the beginningOffset[0]
[2022-11-01 22:19:32.522364]NOTICE KafkaProducer[ddc358d6-e8b1c6c1] initializes with properties[bootstrap.servers=127.0.0.1:40091,127.0.0.1:40092,127.0.0.1:40093|client.id=ddc358d6-e8b1c6c1|log_level=5]
[2022-11-01 22:19:32.839425] ProduceMessages: 3 messages have been sent to 6f794424-c55fa042-0
[2022-11-01 22:19:37.857922] KafkaConsumer[d86cbe85-bce18c70] polled 3 messages
[2022-11-01 22:19:37.867516]NOTICE KafkaConsumer[d86cbe85-bce18c70] re-balance event triggered[REVOKE_PARTITIONS], cooperative[disabled], topic-partitions[6f794424-c55fa042-0,6f794424-c55fa042-1,6f794424-c55fa042-2,6f794424-c55fa042-3,6f794424-c55fa042-4]
[2022-11-01 22:19:37.872005]NOTICE KafkaConsumer[d86cbe85-bce18c70] closed
Broker[-1 - plaintext://GroupCoordinator:0] ==> DOWN
Broker[-1 - plaintext://GroupCoordinator:0] ==> INIT
Broker[1 - plaintext://127.0.0.1:40092] ==> DOWN
Broker[-1 - plaintext://:0] ==> DOWN
Broker[0 - plaintext://127.0.0.1:40091] ==> DOWN
Broker[-1 - plaintext://GroupCoordinator:0] ==> DOWN
Broker[2 - plaintext://127.0.0.1:40093] ==> DOWN
[       OK ] KafkaConsumer.BasicPoll (20086 ms)

```