### PR TITLE
Suppress error from rd_kafka_conf_set while setting enable.manual.events.poll

### DIFF
--- a/include/kafka/KafkaClient.h
+++ b/include/kafka/KafkaClient.h
@@ -292,7 +292,7 @@ KafkaClient::KafkaClient(ClientType                     clientType,
                          const Properties&              properties,
                          const ConfigCallbacksRegister& extraConfigRegister)
 {
-    static const std::set<std::string> PRIVATE_PROPERTY_KEYS = { "max.poll.records" };
+    static const std::set<std::string> PRIVATE_PROPERTY_KEYS = { "max.poll.records", "enable.manual.events.poll" };
 
     // Save clientID
     if (auto clientId = properties.getProperty(Config::CLIENT_ID))


### PR DESCRIPTION
ERR KafkaProducer[5ff24ee4-fd1e0bcc] failed to be initialized with property[enable.manual.events.poll:true], result[-2]