### PR TITLE
Fix `gcc-13` build failure (missing `<cstdint>` include)

### DIFF
--- a/include/kafka/addons/KafkaMetrics.h
+++ b/include/kafka/addons/KafkaMetrics.h
@@ -8,6 +8,7 @@
 #include <rapidjson/writer.h>
 
 #include <algorithm>
+#include <cstdint>
 #include <iostream>
 #include <sstream>
 #include <stdexcept>


### PR DESCRIPTION
Without the change build on `gcc-13` fails as:

    In file included from /build/source/tests/unit/TestKafkaMetrics.cc:1:
    /build/source/include/kafka/addons/KafkaMetrics.h:46:22: error: 'int64_t' is not a member of 'std'; did you mean 'int64_t'?
       46 |     ResultsType<std::int64_t> getInt(const KeysType& keys) const { return get<std::int64_t>(keys); }
          |                      ^~~~~~~