### PR TITLE
Update the KafkaException using modern practices

### DIFF
--- a/include/kafka/KafkaException.h
+++ b/include/kafka/KafkaException.h
@@ -11,6 +11,7 @@
 #include <chrono>
 #include <exception>
 #include <string>
+#include <source_location>
 
 
 namespace KAFKA_API {
@@ -21,10 +22,10 @@ namespace KAFKA_API {
 class KafkaException: public std::exception
 {
 public:
-    KafkaException(const char* filename, std::size_t lineno, const Error& error)
+    KafkaException(const std::source_location location = std::source_location::current(), const Error& error)
         : _when(std::chrono::system_clock::now()),
-          _filename(filename),
-          _lineno(lineno),
+          _filename(location.file_name()),
+          _lineno(location.line()),
           _error(std::make_shared<Error>(error))
     {}
 
@@ -53,7 +54,7 @@ private:
 };
 
 
-#define KAFKA_THROW_ERROR(error)          throw KafkaException(__FILE__, __LINE__, error)
+#define KAFKA_THROW_ERROR(error)          throw KafkaException(error)
 #define KAFKA_THROW_IF_WITH_ERROR(error)  if (error) KAFKA_THROW_ERROR(error)
 
 } // end of KAFKA_API


### PR DESCRIPTION
```
KafkaException(const char* filename, std::size_t lineno, const Error& error)
        : _when(std::chrono::system_clock::now()),
          _filename(filename),
          _lineno(lineno),
          _error(std::make_shared<Error>(error))
    {}
```

In the existing method, `filename` and `lineno` are expressed as follows, but in C++20, you can use the **source_location** feature. </br></br>

```
KafkaException(const std::source_location location = std::source_location::current(), const Error& error)
        : _when(std::chrono::system_clock::now()),
          _filename(location.file_name()),
          _lineno(location.line()),
          _error(std::make_shared<Error>(error))
    {}

```
  
</br>
It may not be very significant, but I believe it is meaningful as it aligns with modern C++ syntax for this project.