### PR TITLE
#158 but for MacOS: pass library existence check when dynamic library exists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,7 +66,7 @@ if (NOT BUILD_OPTION_DOC_ONLY)
         message(FATAL_ERROR "Could not find headers for librdkafka!")
     endif ()
 
-    if (EXISTS "${LIBRDKAFKA_LIBRARY_DIR}/librdkafka.a" OR EXISTS "${LIBRDKAFKA_LIBRARY_DIR}/librdkafka.so" OR EXISTS "${LIBRDKAFKA_LIBRARY_DIR}/rdkafka.lib" )
+    if (EXISTS "${LIBRDKAFKA_LIBRARY_DIR}/librdkafka.a" OR EXISTS "${LIBRDKAFKA_LIBRARY_DIR}/librdkafka.so" OR EXISTS "${LIBRDKAFKA_LIBRARY_DIR}/rdkafka.lib" OR EXISTS "${LIBRDKAFKA_LIBRARY_DIR}/librdkafka.dylib" )
         message(STATUS "librdkafka library directory: ${LIBRDKAFKA_LIBRARY_DIR}")
     else ()
         message(FATAL_ERROR "Could not find library for librdkafka!")


### PR DESCRIPTION
#159 added support for using shared-library-only builds of rdkafka, but only for linux. This repeats that for MacOS. This turned out to be necessary while switching rdkafka to CMake on nixpkgs [here](https://github.com/NixOS/nixpkgs/pull/349725).

Side note: i contemplated also adding windows library names, but I have no idea what the naming scheme there is, and I think modern-cpp-kafka has no business doing these checks in the first place, but if anything, it might be better to use some common mechanism like `find_library` or `pkg_check_modules` (no idea which is proper) and provide a way to opt out of the check. I btw also have never touched a MacOS, and I don't know whether this is sane, all I know is that it works on nixpkgs CI.
 